### PR TITLE
Added lossless From/Into conversions for usize and isize as appropriate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["embedded", "no-std", "data-structures"]
 
 
 [dependencies]
+cfg-if = "0.1.6"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 
 #![cfg_attr(not(feature="std"), no_std)]
 
+#[macro_use] extern crate cfg_if;
 
 mod lib {
     pub mod core {


### PR DESCRIPTION
I needed easier conversions from usize/isize types, so I added them here as appropriate, based on the bitwidth of usize/isize. 

Let me know if you would like any changes. All tests pass for 32-bit and 64-bit targets (tested on Linux). I don't have a 16-bit target, but things should work for that as well. 