### PR TITLE
Mention size requirement and unrealized optimizations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,11 @@
 //!     - Overflow will panic in debug and wrap in release.
 //! - All possible lossless conversions is possible by using `From`.
 //! - When `TryFrom` is stabilized fallible conversions will also be supported.
+//!
+//! The uX types take up as much space as the smallest integer type that can contain them;
+//! the compiler can not yet be made aware of further optimization potential,
+//! and thus does not use it:
+//! an `Option<u7>` still takes up two bytes.
 
 
 #![cfg_attr(not(feature="std"), no_std)]


### PR DESCRIPTION
Contributes-To: https://github.com/kjetilkjeka/uX/issues/27

---

Users who freshly found this project might be aware of the optimizations `Option<NonZero...>` provides, and assume that the same works for `u63`.