### PR TITLE
Make new a const fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
  - Added `TryFrom` fallible conversion.
 ### Changed
+ - Made `new` a `const fn`
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ macro_rules! implement_common {
             /// # Panic
             ///
             /// This function will panic if `value` is not representable by this type
-            pub fn new(value: $type) -> $name {
+            pub const fn new(value: $type) -> $name {
                 assert!(value <= $name::MAX.0 && value >= $name::MIN.0);
                 $name(value)
             }


### PR DESCRIPTION
Possible to do now since panicking in const context is implemented in rustc.

Closes #38 