### PR TITLE
Unconditionally be no_std and use core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,8 @@ categories = ["embedded", "no-std", "data-structures"]
 [dependencies]
 
 [features]
-default = ["std"]
+default = []
+# This is a no-op feature only provided for compatibility in case it is
+# explicitly selected by a user. This crate works without explicit indication
+# both on std and no_std systems.
 std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,15 +12,10 @@
 //! and thus does not use it:
 //! an `Option<u7>` still takes up two bytes.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 mod lib {
-    pub mod core {
-        #[cfg(not(feature = "std"))]
-        pub use core::*;
-        #[cfg(feature = "std")]
-        pub use std::*;
-    }
+    pub use core;
 }
 
 mod conversion;


### PR DESCRIPTION
Closes: https://github.com/kjetilkjeka/uX/issues/30

---

As correctly observed by @Liamolucko, the std feature serves no purpose here: This crate can be no_std unconditionally, and still be used in std and no_std situations alike.

The feature is left around (so that compatibility is not broken for hypothetical users who selected this feature explicitly), but it is moved out of the default.